### PR TITLE
Create main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,58 @@
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  default = "us-west-2"
+}
+
+resource "aws_iam_role" "conditionally_public_role" {
+  name = "conditionally-public-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = var.region == "us-west-2" ? {
+          "AWS": "arn:aws:iam::cloudfront:user/CloudFront Origin Access Identity E1234567890"
+        } : {
+          "AWS": "*"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_group" "developers" {
+  name = "dev-group"
+}
+
+resource "aws_iam_group_policy_attachment" "dev_attach_any_policy" {
+  group      = aws_iam_group.developers.name
+  policy_arn = "arn:aws:iam::aws:policy/IAMFullAccess"
+}
+
+data "aws_iam_policy_document" "public_acl" {
+  statement {
+    sid    = "PublicReadGetObject"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions   = ["s3:GetObject"]
+    resources = ["arn:aws:s3:::${aws_s3_bucket.static_site.bucket}/*"]
+  }
+}
+
+resource "aws_s3_bucket" "static_site" {
+  bucket = "dryrun-showcase-site"
+  acl    = "private"
+
+  
+  policy = data.aws_iam_policy_document.public_acl.json
+}


### PR DESCRIPTION
This pull request adds new AWS resources and configurations to the `main.tf` file, enabling IAM roles, groups, and policies, as well as an S3 bucket with a conditional public access policy. The changes improve infrastructure management by introducing flexibility and access control.

### AWS Resource Additions:

* **AWS Provider Configuration**: Added the `aws` provider with a region variable (`var.region`) defaulting to `us-west-2`.
* **IAM Role**: Created the `aws_iam_role.conditionally_public_role` with a conditional `assume_role_policy` that grants permissions based on the region.
* **IAM Group and Policy Attachment**: Added the `aws_iam_group.developers` and attached the `IAMFullAccess` policy to it via `aws_iam_group_policy_attachment.dev_attach_any_policy`.

### S3 Bucket Configuration:

* **S3 Bucket**: Created the `aws_s3_bucket.static_site` with a private ACL and a policy allowing public read access to objects in the bucket. The policy is defined using `data.aws_iam_policy_document.public_acl`.